### PR TITLE
Add badge for install size & use badgen.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The up-to-date and reliable Google's libphonenumber package for node.js. Zero de
 
 [![npm version][npm-image]][npm-url]
 [![build status][travis-image]][travis-url]
+[![install size][packagephobia-image]][packagephobia-url]
 
 ## Introduction
 
@@ -293,7 +294,9 @@ The exceptional work on `libphonenumber` was made possible by these [committers 
 
 This package is licensed under MIT. The bundled [libphonenumber](https://github.com/googlei18n/libphonenumber/blob/master/LICENSE) library is licensed under Apache 2.0.
 
-[npm-image]: https://img.shields.io/npm/v/google-libphonenumber.svg?style=flat-square
+[npm-image]: https://flat.badgen.net/npm/v/google-libphonenumber
 [npm-url]: https://npmjs.org/package/google-libphonenumber
-[travis-image]: https://img.shields.io/travis/ruimarinho/google-libphonenumber.svg?style=flat-square
+[travis-image]: https://flat.badgen.net/travis/ruimarinho/google-libphonenumber
 [travis-url]: https://travis-ci.org/ruimarinho/google-libphonenumber
+[packagephobia-image]: https://flat.badgen.net/packagephobia/install/google-libphonenumber
+[packagephobia-url]: https://packagephobia.now.sh/result?p=google-libphonenumber


### PR DESCRIPTION
The travis badge was showing failing even though `master` was passing.
This was likely because the `support/update-libphonenumber-8-9-13` branch was failing.

I took this opportunity to clean up the badges so travis looks at master branch and added a new badge to show the npm install size.

These badges use https://flat.badgen.net which is faster than shields.io in most cases.