### PR TITLE
Update package.json to use SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "name": "Rui Marinho",
     "email": "ruipmarinho@gmail.com"
   },
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "(MIT AND Apache-2.0)",
   "homepage": "https://ruimarinho.github.io/google-libphonenumber/",
   "bugs": "https://github.com/ruimarinho/google-libphonenumber/issues",
   "repository": {


### PR DESCRIPTION
Some organizations and projects automatically validate against package licenses as described in their `package.json`, with the intent of only allowing packages that use one of an organization-approved list of licenses. Using "SEE LICENSE IN LICENSE" is valid according to the [`package.json` guidelines](https://docs.npmjs.com/files/package.json#license), but only if your package truly has a custom license that isn't on the SPDX list. This package seems to use a strict conjunction of the MIT and Apache-2.0 licenses, and so the `package.json` should reflect that so that automated systems will whitelist the library where appropriate.