### PR TITLE
Add Travis CI retries on the `script` phase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ node_js:
   - 7
 
 sudo: false
+
+script: travis_retry npm test


### PR DESCRIPTION
Starting three months ago, the PR builds are failing due to sporadic failures of the Google Closure Service, which causes a faulty Browserify bundle. (See: https://travis-ci.org/ruimarinho/google-libphonenumber/pull_requests)

This PR wraps the Travis `script` phase in a [travis_retry](https://docs.travis-ci.com/user/common-build-problems/#travis_retry) to aim for successful builds.