### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: release
+
+jobs:
+  release:
+    name: Tag Release
+    if: contains(github.event.head_commit.message, 'Update libphonenumber@')
+    runs-on: ubuntu-latest
+    steps:
+      # The deploy key allows pushing to master past the required status
+      # checks ruleset and, unlike the workflow token, the tag push it
+      # makes triggers the publish workflow.
+      - uses: actions/checkout@v5
+        with:
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 24
+      # --ignore-scripts skips the local dist rebuild, matching the
+      # documented release process — the publish workflow rebuilds dist
+      # from src and that artifact is what ships to npm.
+      - name: Bump version and tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          npm version patch --ignore-scripts -m "Release %s"
+      - run: git push --follow-tags origin master


### PR DESCRIPTION
Automatically tags and releases a new version whenever a libphonenumber metadata update lands on `master`.

The workflow runs on pushes to `master` whose head commit is an `Update libphonenumber@x.y.z` merge. It bumps the patch version (`Release x.y.z` commit, matching the existing convention), tags it, and pushes using the `RELEASE_DEPLOY_KEY` deploy key — which bypasses the required checks ruleset and, unlike the workflow token, triggers the existing publish workflow on the tag push, so npm publishing and GitHub release creation continue to happen from `publish.yaml` (keeping npm trusted publishing intact).

A `concurrency` group serializes runs if two updates merge close together, and the `Release x.y.z` commit it pushes does not match the trigger condition, so the workflow does not re-trigger itself.